### PR TITLE
fallback on copy if move gives permission denied

### DIFF
--- a/lib/Archive/Zip/Archive.pm
+++ b/lib/Archive/Zip/Archive.pm
@@ -481,7 +481,7 @@ sub overwriteAs {
     }
 
     # move the temp to the original name (possibly copying)
-    unless ( File::Copy::move( $tempName, $zipName ) ) {
+    unless ( File::Copy::move( $tempName, $zipName ) || File::Copy::copy( $tempName, $zipName) ) {
         $err = $!;
         rename( $backupName, $zipName );
         unlink($tempName);


### PR DESCRIPTION
This fixes a test error that I am seeing with Streawberry Perl

Move on a temp file with CLEANUP => 1 apparently gives a permission denied error on MSWin32.  Copy seems safe fallback since the file should be deleted when the process terminates.
