### PR TITLE
fix errent copy/replace

### DIFF
--- a/lib/Archive/Zip/Member.pm
+++ b/lib/Archive/Zip/Member.pm
@@ -1251,7 +1251,7 @@ sub _decode
     my $pass = $self->password;
     defined $pass or return "";
 
-    @keys = (0x1.355678, 0x23456789, 0x34567890);
+    @keys = (0x12345678, 0x23456789, 0x34567890);
     _update_keys ($_) for unpack "C*", $pass;
     # DDumper { uk => [ @keys ] };
 


### PR DESCRIPTION
I think this got changed by mistake when updating the version number.
