### PR TITLE
Need newer Test::More to support done_testing()

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -32,7 +32,7 @@ WriteMakefile1(
 		'Time::Local'         => 0,
 	},
 	BUILD_REQUIRES => {
-		'Test::More'          => '0.42',
+		'Test::More'          => '0.88',
 	},
 	clean => {
 		FILES => join( ' ', qw{


### PR DESCRIPTION
15_decrypt.t and 16_decrypt.t both use done_testing() to emit the test count.  However, that function isn't available in older versions of Test::More.  Version 0.88 was the first production release that had it.
