### PR TITLE
Setting unicode flag for each member when using $Archive::Zip::UNICODE

### DIFF
--- a/lib/Archive/Zip/Member.pm
+++ b/lib/Archive/Zip/Member.pm
@@ -107,7 +107,7 @@ sub new {
         'fileAttributeFormat'      => FA_UNIX,
         'versionMadeBy'            => 20,
         'versionNeededToExtract'   => 20,
-        'bitFlag'                  => 0,
+        'bitFlag'                  => ($Archive::Zip::UNICODE ? 0x0800 : 0),
         'compressionMethod'        => COMPRESSION_STORED,
         'desiredCompressionMethod' => COMPRESSION_STORED,
         'desiredCompressionLevel'  => COMPRESSION_LEVEL_NONE,


### PR DESCRIPTION
It seems like the GPF bit 11 ("UTF-8") is only set for the entire archive, however, not for each individual member. See https://rt.cpan.org/Ticket/Display.html?id=98553
Please find attached a patch that also sets 'bitFlag |= 0x0800' for each member.

Otherwise, I see warnings (and sometimes even errors prohibiting extraction of an archive) such as:

```
     mismatch between local and central GPF bit 11 ("UTF-8"),
     continuing with central flag (IsUTF8 = 1)
```

(here 'UnZip 6.00 of 20 April 2009, by Info-ZIP'; error for 7zip).
