### PR TITLE
Win32 with ZIP executable can't create temp file

### DIFF
--- a/t/common.pm
+++ b/t/common.pm
@@ -9,9 +9,9 @@ BEGIN { mkdir 'testdir' }
 use constant TESTDIR =>
   File::Spec->abs2rel(tempdir(DIR => 'testdir', CLEANUP => 1));
 use constant INPUTZIP =>
-  (tempfile('testin-XXXXX', SUFFIX => '.zip', TMPDIR => 1, UNLINK => 1))[1];
+  (tempfile('testin-XXXXX', SUFFIX => '.zip', TMPDIR => 1, $^O eq 'MSWin32' ? () : (UNLINK => 1)))[1];
 use constant OUTPUTZIP =>
-  (tempfile('testout-XXXXX', SUFFIX => '.zip', TMPDIR => 1, UNLINK => 1))[1];
+  (tempfile('testout-XXXXX', SUFFIX => '.zip', TMPDIR => 1, $^O eq 'MSWin32' ? () : (UNLINK => 1)))[1];
 
 # Do we have the 'zip' and 'unzip' programs?
 # Embed a copy of the module, rather than adding a dependency

--- a/t/common.pm
+++ b/t/common.pm
@@ -6,8 +6,11 @@ use strict;
 use File::Temp qw(tempfile tempdir);
 use File::Spec;
 BEGIN { mkdir 'testdir' }
-use constant TESTDIR =>
-  File::Spec->abs2rel(tempdir(DIR => 'testdir', CLEANUP => 1));
+use constant TESTDIR => do {
+    my $tmpdir = File::Spec->abs2rel(tempdir(DIR => 'testdir', CLEANUP => 1));
+    $tmpdir =~ s!\\!/!g if $^O eq 'MSWin32';
+    $tmpdir
+};
 use constant INPUTZIP =>
   (tempfile('testin-XXXXX', SUFFIX => '.zip', TMPDIR => 1, $^O eq 'MSWin32' ? () : (UNLINK => 1)))[1];
 use constant OUTPUTZIP =>


### PR DESCRIPTION
An open filehandle means command-line zip.exe can't write to the file.

Turning off `UNLINK => 1` in the call to `tempfile` allows `tempfile` to *not* return an open filehandle.

This will leave junk in the user's temp directory, but it *works*, so... trade-off?  Without this fix, you get this at the top of `prove t\02_main.t`:

    t\02_main.t .. The process cannot access the file because it is being used by another process.
    warning: C:\Strawberry\perl\bin\perl.exe -pe "BEGIN{binmode(STDIN);binmode(STDOUT)}" doesn't seem to work, may skip some tests at t/common.pm line 189.
    warning: zip  doesn't seem to work, may skip some tests at t/common.pm line 204.
      End-of-central-directory signature not found.  Either this file is not
      a zipfile, or it constitutes one disk of a multi-part archive.  In the
      latter case the central directory and zipfile comment will be found on
      the last disk(s) of this archive.
    unzip:  cannot find zipfile directory in C:/Users/jdavis/AppData/Local/Temp/testin-QiNyW.zip,
            and cannot find C:/Users/jdavis/AppData/Local/Temp/testin-QiNyW.zip.zip, period.
    warning: unzip -t  doesn't seem to work, may skip some tests at t/common.pm line 220.
    t\02_main.t .. 1/141
    # You might see an expected 'zipfile is empty' warning now.

With this change:

    # You might see an expected 'zipfile is empty' warning now.
    warning [C:/Users/jdavis/AppData/Local/Temp/testout-_g2NT.zip]:  zipfile is empty