### PR TITLE
FreeBSD's unzip sets $? to 0 for empty zip file

### DIFF
--- a/t/02_main.t
+++ b/t/02_main.t
@@ -79,6 +79,10 @@ SKIP: {
     # STDERR->print("status= $status, out=$zipout\n");
 
     skip("test zip doesn't work", 1) if $testZipDoesntWork;
+
+    skip("freebsd's unzip doesn't care about empty zips", 1)
+        if $^O eq 'freebsd';
+
     ok($status != 0);
 }
 


### PR DESCRIPTION
This just skips that one test if we're running on FreeBSD, because the `unzip` that comes with FreeBSD doesn't consider an empty zip file something to return a non-zero result about.

InfoZIP on Windows:

    C:\temp>unzip -t foo.zip
    Archive:  foo.zip
    warning [foo.zip]:  zipfile is empty

    C:\temp>echo %ERRORLEVEL%
    1

InfoZIP in Ubuntu:

    jdavis@daedalus:/tmp$ unzip -t foo.zip
    Archive:  foo.zip
    warning [foo.zip]:  zipfile is empty
    jdavis@daedalus:/tmp$ echo $?
    1

unzip in FreeBSD:

    [/tmp]# unzip -t foo.zip
    Archive:  foo.zip
    No errors detected in compressed data of foo.zip.
    [/tmp]# echo $?
    0