### PR TITLE
Fix t/08_readmember_record_sep.t for Win32

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ perldoc command.
 
 Bugs should be reported via the CPAN bug tracker
 
-	http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Archive-Zip
+http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Archive-Zip
 
 For other issues contact the maintainer
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# Archive-Zip
+
+The Archive::Zip module allows a Perl program to create, manipulate, read, 
+and write Zip archive files.
+
+See https://metacpan.org/pod/Archive::Zip for more information.
+
+
+# INSTALLATION
+
+To install this module, run the following commands:
+
+	perl Makefile.PL
+	make
+	make test
+	make install
+
+
+# SUPPORT AND DOCUMENTATION
+
+After installing, you can find documentation for this module with the
+perldoc command.
+
+    perldoc Archive::Zip
+
+
+# SUPPORT
+
+Bugs should be reported via the CPAN bug tracker
+
+	http://rt.cpan.org/NoAuth/ReportBug.html?Queue=Archive-Zip
+
+For other issues contact the maintainer
+
+
+# AUTHOR
+
+Currently maintained by Fred Moyer <fred@redhotpenguin.com>
+
+Previously maintained by Adam Kennedy <adamk@cpan.org>
+
+Previously maintained by Steve Peters <steve@fisharerojo.org>.
+
+File attributes code by Maurice Aubrey <maurice@lovelyfilth.com>.
+
+Originally by Ned Konz <nedkonz@cpan.org>.
+
+
+# COPYRIGHT
+
+Some parts copyright 2006 - 2012 Adam Kennedy.
+
+Some parts copyright 2005 Steve Peters.
+
+Original work copyright 2000 - 2004 Ned Konz.
+
+This program is free software; you can redistribute it and/or modify it 
+under the same terms as Perl itself.

--- a/t/08_readmember_record_sep.t
+++ b/t/08_readmember_record_sep.t
@@ -12,14 +12,15 @@ use File::Spec;
 
 use Test::More;
 
+my $nl;
 BEGIN {
-    if ($^O eq 'MSWin32') {
-        plan(skip_all => 'Ignoring failing tests on Win32');
-    } else {
-        plan(tests => 13);
-    }
+	plan(tests => 13);
+	$nl = $^O eq 'MSWin32' ? "\r\n" : "\n";
 }
 use t::common;
+
+# normalize newlines for the platform we are running on
+sub norm_nl($) { local $_ = shift; s/\r?\n/$nl/g; return $_; }
 
 SCOPE: {
     my $filename = File::Spec->catfile(TESTDIR, "member_read_xml_like1.zip");
@@ -28,7 +29,7 @@ SCOPE: {
     # TEST
     isa_ok($zip, "Archive::Zip", "Testing that \$zip is an Archive::Zip");
 
-    my $data = <<"EOF";
+    my $data = norm_nl(<<"EOF");
 One Line
 Two Lines
 </tag>
@@ -77,14 +78,14 @@ EOF
         # TEST
         is(
             $fh->getline(),
-            "One Line\nTwo Lines\n",
+            norm_nl("One Line\nTwo Lines\n"),
             "Testing the first \"line\" when \$/ is set."
         );
 
         # TEST
         is(
             $fh->getline(),
-            "Three Lines\nFour Lines\nFive Lines\n",
+            norm_nl("Three Lines\nFour Lines\nFive Lines\n"),
             "Testing the second \"line\" when \$/ is set."
         );
     }
@@ -103,14 +104,14 @@ EOF
         # TEST
         is(
             $fh->getline(),
-            "One Line\nTwo Lines\n",
+            norm_nl("One Line\nTwo Lines\n"),
             "Testing the first line when input_record_separator is set."
         );
 
         # TEST
         is(
             $fh->getline(),
-            "Three Lines\nFour Lines\nFive Lines\n",
+            norm_nl("Three Lines\nFour Lines\nFive Lines\n"),
             "Testing the second line when input_record_separator is set."
         );
     }
@@ -133,7 +134,7 @@ EOF
             "Testing the first \"line\" in a both set read");
 
         # TEST
-        is($fh->getline(), "Line\nTwo",
+        is($fh->getline(), norm_nl("Line\nTwo"),
             "Testing the second \"line\" in a both set read.");
     }
 }


### PR DESCRIPTION
The test was being skipped in Win32 because of test failures.

The test failures were caused by A::Z reading/writing members in binary
mode, i.e. without any newline conversion. This has to be taken into
account in the test, by:
- Converting "\n" into "\r\n" in the data file prior to writing to the
  zip file, if running in Win32.
- Converting "\n" of the expected strings returned by getline() into
  "\r\n" before checking, if running in Win32.

These changes were made to the test file and all tests pass on Win32.
On other platforms the changes have no effect, and should pass the tests
also.