### PR TITLE
script/crc32: When 8 byte checksum is in filename, check it

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Archive-Zip
 
+1.51 Tue 22 Sep 2015
+    - Compare vs filename checksum in crc32 script [github/talisein]
+
 1.50 Tue 25 Aug 2015
     - Fix t/08_readmember_record_sep.t for Win32 [github/pauloscustodio]
 

--- a/script/crc32
+++ b/script/crc32
@@ -10,7 +10,7 @@ use FileHandle;
 
 use vars qw( $VERSION );
 BEGIN {
-    $VERSION = '1.31_04';
+    $VERSION = '1.51';
 }
 
 my $totalFiles = scalar(@ARGV);
@@ -31,7 +31,18 @@ foreach my $file (@ARGV) {
     while ( $bytesRead = $fh->read( $buffer, 32768 ) ) {
         $crc = Archive::Zip::computeCRC32( $buffer, $crc );
     }
-    printf( "%08x", $crc );
+    my $fileCrc = sprintf("%08x", $crc);
+    printf("$fileCrc");
     print("\t$file") if ( $totalFiles > 1 );
+
+    if ( $file =~ /[^[:xdigit:]]([[:xdigit:]]{8})[^[:xdigit:]]/ ) {
+	my $filenameCrc = $1;
+	if ( lc($filenameCrc) eq lc($fileCrc) ) {
+	    print("\tOK")
+	} else {
+	    print("\tBAD $fileCrc != $filenameCrc");
+        }
+    }
+
     print("\n");
 }


### PR DESCRIPTION
It is not uncommon for crc32 checksums to be stored in filenames, e.g. My_photo_album_[0123CDEF].zip

This patch will have the script look for a hexadecimal substring of exactly 8 characters (no more, no less). If there is such a string, a new column of output will appear, either "OK" or "BAD AFAFAFAF != 0123CDEF"