### PR TITLE
Patch to ensure filehandles created by Archive::Zip::tempFile are closed

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -55,6 +55,7 @@ t/19_bug_101240.t
 t/20_bug_github11.t
 t/21_zip64.t
 t/22_deflated_dir.t
+t/23_closed_handler.t
 t/badjpeg/expected.jpg
 t/badjpeg/source.zip
 t/common.pm

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -37,6 +37,7 @@ WriteMakefile1(
     },
     BUILD_REQUIRES => {
         'Test::More' => '0.88',
+        'Test::MockModule' => 0,
     },
     clean => {
         FILES => join( ' ', qw{

--- a/lib/Archive/Zip.pm
+++ b/lib/Archive/Zip.pm
@@ -517,6 +517,7 @@ sub tempFile {
         $dir ? (DIR => $dir) : ());
     return (undef, undef) unless $fh;
     my ($status, $newfh) = _newFileHandle($fh, 'w+');
+    $fh->close();
     return ($newfh, $filename);
 }
 

--- a/t/23_closed_handler.t
+++ b/t/23_closed_handler.t
@@ -1,0 +1,38 @@
+#!/usr/bin/perl
+
+# Test to make sure temporal filehandles created by Archive::Zip::tempFile are closed properly
+
+use strict;
+use warnings;
+
+use Archive::Zip;
+use Test::MockModule;
+
+use Test::More tests => 2;
+
+# array to store open filhandles
+my @opened_filehandles;
+
+# mocking File::Temp to store returned filehandles
+my $mock_file_temp = Test::MockModule->new('File::Temp');
+
+my $previous_tempfile_sub = \&File::Temp::tmpfile;
+$mock_file_temp->mock(
+    tempfile => sub {
+        my ( $fh, $filename ) = $previous_tempfile_sub->(@_);
+        push( @opened_filehandles, $fh );
+        return ( $fh, $filename );
+    }
+);
+
+# calling method
+Archive::Zip::tempFile();
+
+# testing filehandles are closed
+ok( scalar @opened_filehandles == 1, "One filehandle was created" );
+ok( !defined $opened_filehandles[0]
+      || !defined fileno( $opened_filehandles[0] )
+      || fileno( $opened_filehandles[0] ) == -1,
+    "Filehandle is closed"
+);
+


### PR DESCRIPTION
Hopes this could help to avoid problems of "Too many open files" when adding and overwriting a large amount of files to a zip file.
As people describes in http://www.perlmonks.org/?node_id=1140199
One of the two filehandles (the internal one) created in Archive::Zip::tempFile was never closed, and then retained by the process.
