### PR TITLE
Upgrade metadata to version 2

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -9,8 +9,18 @@ use ExtUtils::MakeMaker;
 
 WriteMakefile1(
     META_MERGE => {
+        'meta-spec' => { version => 2 },
+        dynamic_config => 0,
         resources => {
-            repository => 'https://github.com/redhotpenguin/perl-Archive-Zip-svn',
+            repository => {
+                url => 'https://github.com/redhotpenguin/perl-Archive-Zip.git',
+                web => 'https://github.com/redhotpenguin/perl-Archive-Zip',
+                type => 'git',
+            },
+            bugtracker => {
+                mailto => 'bug-Archive-Zip@rt.cpan.org',
+                web => 'https://rt.cpan.org/Public/Dist/Display.html?Name=Archive-Zip',
+            },
         },
     },
     NAME         => 'Archive::Zip',
@@ -35,7 +45,7 @@ WriteMakefile1(
         'IO::Seekable' => 0,
         'Time::Local'  => 0,
     },
-    BUILD_REQUIRES => {
+    TEST_REQUIRES => {
         'Test::More' => '0.88',
         'Test::MockModule' => 0,
     },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -8,6 +8,9 @@ use Config;
 use ExtUtils::MakeMaker;
 
 WriteMakefile1(
+    #BUILD_REQUIRES => {
+    #},
+
     META_MERGE => {
         'meta-spec' => { version => 2 },
         dynamic_config => 0,
@@ -75,27 +78,32 @@ WriteMakefile1(
     ABSTRACT_FROM    => 'lib/Archive/Zip.pm',
 );
 
-sub WriteMakefile1 {    #Written by Alexandr Ciornii, version 0.21. Added by eumm-upgrade.
-    my %params       = @_;
-    my $eumm_version = $ExtUtils::MakeMaker::VERSION;
-    $eumm_version = eval $eumm_version;
+
+sub WriteMakefile1 {  #Compatibility code for old versions of EU::MM. Written by Alexandr Ciornii, version 0.23. Added by eumm-upgrade.
+    my %params=@_;
+    my $eumm_version=$ExtUtils::MakeMaker::VERSION;
+    $eumm_version=eval $eumm_version;
     die "EXTRA_META is deprecated" if exists $params{EXTRA_META};
     die "License not specified" if not exists $params{LICENSE};
-    if ( $params{BUILD_REQUIRES} and $eumm_version < 6.5503 ) {
-
+    if ($params{AUTHOR} and ref($params{AUTHOR}) eq 'ARRAY' and $eumm_version < 6.5705) {
+        $params{META_ADD}->{author}=$params{AUTHOR};
+        $params{AUTHOR}=join(', ',@{$params{AUTHOR}});
+    }
+    if ($params{TEST_REQUIRES} and $eumm_version < 6.64) {
+        $params{BUILD_REQUIRES}={ %{$params{BUILD_REQUIRES} || {}} , %{$params{TEST_REQUIRES}} };
+        delete $params{TEST_REQUIRES};
+    }
+    if ($params{BUILD_REQUIRES} and $eumm_version < 6.5503) {
         #EUMM 6.5502 has problems with BUILD_REQUIRES
-        $params{PREREQ_PM} = { %{ $params{PREREQ_PM} || {} }, %{ $params{BUILD_REQUIRES} } };
+        $params{PREREQ_PM}={ %{$params{PREREQ_PM} || {}} , %{$params{BUILD_REQUIRES}} };
         delete $params{BUILD_REQUIRES};
     }
     delete $params{CONFIGURE_REQUIRES} if $eumm_version < 6.52;
-    delete $params{MIN_PERL_VERSION}   if $eumm_version < 6.48;
-    delete $params{META_MERGE}         if $eumm_version < 6.46;
-    delete $params{META_ADD}           if $eumm_version < 6.46;
-    delete $params{LICENSE}            if $eumm_version < 6.31;
-    delete $params{AUTHOR}             if $] < 5.005;
-    delete $params{ABSTRACT_FROM}      if $] < 5.005;
-    delete $params{BINARY_LOCATION}    if $] < 5.005;
+    delete $params{MIN_PERL_VERSION} if $eumm_version < 6.48;
+    delete $params{META_MERGE} if $eumm_version < 6.46;
+    delete $params{META_ADD} if $eumm_version < 6.46;
+    delete $params{LICENSE} if $eumm_version < 6.31;
 
-    WriteMakefile( %params );
+    WriteMakefile(%params);
 }
 


### PR DESCRIPTION
This enhances the repository and bugtracker information that is listed, properly lists test requirements in the correct phase, and marks the distribution as "you do not need to run Makefile.PL first to figure out what the dependencies are".