### PR TITLE
fix UNICODE issues:

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,12 @@
 Revision history for Perl extension Archive-Zip
 
+
+    - fix $Archive::Zip::UNICODE issues [github/xlat]
+        - on MSWin32 in methods addFile, addDirectory, addTree: the externalFileName was 
+          used in place of newName
+        - make sure that file names are utf8 in memberNames
+        - use Encode on all platform
+
 1.53 Wed 22 Sep 2015
     - rt.cpan.org #107268 - Archive-Zip-1.52.tar.gz is (nearly) empty
       Thanks to SREZIC for the spot on my dad brain sleep schedule error

--- a/lib/Archive/Zip/Member.pm
+++ b/lib/Archive/Zip/Member.pm
@@ -231,6 +231,15 @@ sub fileName {
     return $self->{'fileName'};
 }
 
+sub fileNameAsBytes {
+    my $self  = shift;
+    my $bytes = $self->{'fileName'};
+    if($self->{'bitFlag'} & 0x800){
+        $bytes = Encode::encode_utf8($bytes);
+    }
+    return $bytes;
+}
+
 sub lastModFileDateTime {
     my $modTime = shift->{'lastModFileDateTime'};
     $modTime =~ m/^(\d+)$/;           # untaint
@@ -684,7 +693,7 @@ sub head {
               : $self->compressedSize(),    # may need to be re-written later
             $self->uncompressedSize(),
           ),
-      length($self->fileName()),
+      length($self->fileNameAsBytes()),
       length($self->localExtraField());
 }
 
@@ -706,7 +715,7 @@ sub _writeLocalFileHeader {
 
     # Check for a valid filename or a filename equal to a literal `0'
     if ($self->fileName() || $self->fileName eq '0') {
-        $self->_print($fh, $self->fileName())
+        $self->_print($fh, $self->fileNameAsBytes())
           or return _ioError("writing local header filename");
     }
     if ($self->localExtraField()) {
@@ -729,7 +738,7 @@ sub _writeCentralDirectoryFileHeader {
     my ($fileNameLength, $extraFieldLength, $fileCommentLength);
     {
         use bytes;
-        $fileNameLength    = length($self->fileName());
+        $fileNameLength    = length($self->fileNameAsBytes());
         $extraFieldLength  = length($self->cdExtraField());
         $fileCommentLength = length($self->fileComment());
     }
@@ -756,7 +765,7 @@ sub _writeCentralDirectoryFileHeader {
     $self->_print($fh, $header)
       or return _ioError("writing central directory header");
     if ($fileNameLength) {
-        $self->_print($fh, $self->fileName())
+        $self->_print($fh, $self->fileNameAsBytes())
           or return _ioError("writing central directory header signature");
     }
     if ($extraFieldLength) {

--- a/t/24_unicode_win32.t
+++ b/t/24_unicode_win32.t
@@ -1,0 +1,154 @@
+#!/usr/bin/perl
+
+# tests with $Archive::Zip::UNICODE
+use utf8;       #utf8 source code
+use strict;
+
+BEGIN {
+    $|  = 1;
+    $^W = 1;
+}
+use Test::More;
+use Archive::Zip;
+
+use File::Temp;
+use File::Path;
+use File::Spec;
+
+use t::common;
+
+#Initialy written for MSWin32 only, but I found a bug in memberNames() so
+# other systems should be tested too.
+#if( $^O ne 'MSWin32' ) {
+#    plan skip_all => 'Test relevant only on MSWin32';
+#    done_testing();
+#    exit;
+#}
+
+$Archive::Zip::UNICODE=1;
+
+mkpath([File::Spec->catdir(TESTDIR, 'folder')]);
+my $euro_filename = "euro-€";
+my $zero_file = File::Spec->catfile(TESTDIR, 'folder', $euro_filename);
+open(EURO, ">$zero_file");
+print EURO "File EURO\n";
+close(EURO);
+
+# create member called $euro_filename with addTree
+{
+    my $archive = Archive::Zip->new;
+    $archive->addTree(File::Spec->catfile(TESTDIR, 'folder'), 'folder',);
+    
+    #TEST
+    is_deeply(
+        [ $archive->memberNames()],
+        [ "folder/", "folder/$euro_filename" ],
+        "Checking that a file named with unicode chars was added properly"
+    );
+
+}
+
+# create member called $euro_filename with addString
+{
+    # Create member $euro_filename with addString
+    my $archive = Archive::Zip->new;
+    my $string_member = $archive->addString(TESTSTRING => $euro_filename);
+    $archive->writeToFileNamed(OUTPUTZIP);
+}
+#TEST
+{
+    # Read member $euro_filename
+    my $archive = Archive::Zip->new;
+    is($archive->read(OUTPUTZIP), Archive::Zip::AZ_OK);
+    is_deeply(
+        [$archive->memberNames()],
+        [$euro_filename],
+        "Checking that a file named with unicode chars was added properly by addString");
+}
+unlink(OUTPUTZIP);
+
+{
+    # Create member called $euro_filename with addFile
+    # use a temp file so it's name doesn't match internal name
+    my $tmp_file = File::Temp->new;
+    $tmp_file->print("File EURO\n");
+    $tmp_file->flush;
+    my $archive = Archive::Zip->new;
+    my $string_member = $archive->addFile($tmp_file->filename => $euro_filename);
+    $archive->writeToFileNamed(OUTPUTZIP);
+}
+#TEST
+{
+    # Read member $euro_filename
+    my $archive = Archive::Zip->new;
+    is($archive->read(OUTPUTZIP), Archive::Zip::AZ_OK);
+    is_deeply(
+        [$archive->memberNames()],
+        [$euro_filename],
+        "Checking that a file named with unicode chars was added properly by addFile");
+}
+unlink(OUTPUTZIP);
+
+{
+    # Create member called $euro_filename with addDirectory
+    my $archive = Archive::Zip->new;
+    my $string_member = $archive->addDirectory(
+        File::Spec->catdir(TESTDIR, 'folder') => $euro_filename);
+    $archive->writeToFileNamed(OUTPUTZIP);
+}
+#TEST
+{
+    # Read member $euro_filename
+    my $archive = Archive::Zip->new;
+    is($archive->read(OUTPUTZIP), Archive::Zip::AZ_OK);
+    is_deeply(
+        [$archive->memberNames()],
+        [$euro_filename.'/'],
+        "Checking that a file named with unicode chars was added properly by addDirectory");
+}
+unlink(OUTPUTZIP);
+
+{
+    # Create member called $euro_filename with addFileOrDirectory from a directory
+    my $archive = Archive::Zip->new;
+    my $string_member = $archive->addFileOrDirectory(
+        File::Spec->catdir(TESTDIR, 'folder') => $euro_filename);
+    $archive->writeToFileNamed(OUTPUTZIP);
+}
+#TEST
+{
+    # Read member $euro_filename
+    my $archive = Archive::Zip->new;
+    is($archive->read(OUTPUTZIP), Archive::Zip::AZ_OK);
+    is_deeply(
+        [$archive->memberNames()],
+        [$euro_filename.'/'],
+        "Checking that a file named with unicode chars was added properly by addFileOrDirectory from a direcotry");
+}
+unlink(OUTPUTZIP);
+
+{
+    # Create member called $euro_filename with addFileOrDirectory from a file
+    # use a temp file so it's name doesn't match internal name
+    my $tmp_file = File::Temp->new;
+    $tmp_file->print("File EURO\n");
+    $tmp_file->flush;    
+    my $archive = Archive::Zip->new;
+    my $string_member = $archive->addFileOrDirectory(
+        $tmp_file->filename => $euro_filename);
+    $archive->writeToFileNamed(OUTPUTZIP);
+}
+#TEST
+{
+    # Read member $euro_filename
+    my $archive = Archive::Zip->new;
+    is($archive->read(OUTPUTZIP), Archive::Zip::AZ_OK);
+    is_deeply(
+        [$archive->memberNames()],
+        [$euro_filename],
+        "Checking that a file named with unicode chars was added properly by addFileOrDirectory from a file");
+}
+unlink(OUTPUTZIP);
+
+rmtree([File::Spec->catdir(TESTDIR, 'folder')]);
+done_testing();


### PR DESCRIPTION
! addFile, addDirectory, addTree : on MSWin32 and $A:Z:UNICODE = 1, the externalFileName was used in place of newName
! memberNames : with $A:Z:UNICODE = 1, the returned file names was not upgraded in utf8 but already contain utf8 bytes.
* Encode::encode_utf8 and Encode::decode_utf8 is not plateform dependent anymore.