### PR TITLE
avoid relying on . being in @INC

### DIFF
--- a/t/02_main.t
+++ b/t/02_main.t
@@ -16,7 +16,8 @@ use File::Spec;
 
 use Test::More tests => 141;
 
-use t::common;
+use lib 't';
+use common;
 
 #####################################################################
 # Testing Utility Functions

--- a/t/03_ex.t
+++ b/t/03_ex.t
@@ -11,7 +11,8 @@ use File::Spec;
 use IO::File;
 
 use Test::More tests => 17;
-use t::common;
+use lib 't';
+use common;
 
 sub runPerlCommand {
     my $libs = join(' -I', @INC);

--- a/t/04_readmember.t
+++ b/t/04_readmember.t
@@ -10,7 +10,8 @@ use Archive::Zip qw( :ERROR_CODES :CONSTANTS );
 use Archive::Zip::MemberRead;
 
 use Test::More tests => 10;
-use t::common;
+use lib 't';
+use common;
 
 use constant FILENAME => File::Spec->catfile(TESTDIR, 'member_read.zip');
 

--- a/t/05_tree.t
+++ b/t/05_tree.t
@@ -13,7 +13,8 @@ use FileHandle;
 use File::Spec;
 
 use Test::More tests => 6;
-use t::common;
+use lib 't';
+use common;
 
 use constant FILENAME => File::Spec->catfile(TESTDIR, 'testing.txt');
 

--- a/t/06_update.t
+++ b/t/06_update.t
@@ -14,7 +14,8 @@ use File::Find ();
 use Archive::Zip qw( :ERROR_CODES :CONSTANTS );
 
 use Test::More tests => 12;
-use t::common;
+use lib 't';
+use common;
 
 my ($testFileVolume, $testFileDirs, $testFileName) = File::Spec->splitpath($0);
 

--- a/t/07_filenames_of_0.t
+++ b/t/07_filenames_of_0.t
@@ -18,7 +18,8 @@ use Archive::Zip;
 use File::Path;
 use File::Spec;
 
-use t::common;
+use lib 't';
+use common;
 
 mkpath([File::Spec->catdir(TESTDIR, 'folder')]);
 

--- a/t/08_readmember_record_sep.t
+++ b/t/08_readmember_record_sep.t
@@ -17,7 +17,8 @@ BEGIN {
 	plan(tests => 13);
 	$nl = $^O eq 'MSWin32' ? "\r\n" : "\n";
 }
-use t::common;
+use lib 't';
+use common;
 
 # normalize newlines for the platform we are running on
 sub norm_nl($) { local $_ = shift; s/\r?\n/$nl/g; return $_; }

--- a/t/10_chmod.t
+++ b/t/10_chmod.t
@@ -11,7 +11,8 @@ use File::Spec;
 use File::Path;
 use Archive::Zip;
 
-use t::common;
+use lib 't';
+use common;
 
 sub get_perm {
     my $filename = shift;

--- a/t/14_leading_separator.t
+++ b/t/14_leading_separator.t
@@ -20,7 +20,8 @@ use Archive::Zip;
 use Cwd        ();
 use File::Spec ();
 
-use t::common;
+use lib 't';
+use common;
 
 my $file_relative_path = File::Spec->catfile(TESTDIR, 'file.txt');
 open FH, ">$file_relative_path";

--- a/t/17_101092.t
+++ b/t/17_101092.t
@@ -8,7 +8,8 @@ BEGIN {
 }
 
 use Test::More tests => 2;
-use t::common;
+use lib 't';
+use common;
 
 # RT #101092: Creation of non-standard streamed zip file
 

--- a/t/18_bug_92205.t
+++ b/t/18_bug_92205.t
@@ -8,7 +8,8 @@ BEGIN {
 }
 
 use Test::More tests => 32;
-use t::common;
+use lib 't';
+use common;
 use Archive::Zip qw( :CONSTANTS );
 
 

--- a/t/19_bug_101240.t
+++ b/t/19_bug_101240.t
@@ -12,7 +12,8 @@ use File::Spec;
 use File::Path;
 use Archive::Zip qw(:CONSTANTS);
 
-use t::common;
+use lib 't';
+use common;
 
 #101240: Possible issue with zero length files on Win32 when UNICODE is enabled
 

--- a/t/20_bug_github11.t
+++ b/t/20_bug_github11.t
@@ -9,7 +9,8 @@ use warnings;
 use Archive::Zip qw( :ERROR_CODES );
 use File::Spec;
 use File::Path;
-use t::common;
+use lib 't';
+use common;
 
 use Test::More tests => 2;
 

--- a/t/21_zip64.t
+++ b/t/21_zip64.t
@@ -7,7 +7,8 @@ use warnings;
 
 use Archive::Zip qw( :ERROR_CODES );
 use File::Spec;
-use t::common;
+use lib 't';
+use common;
 
 use Test::More tests => 1;
 

--- a/t/22_deflated_dir.t
+++ b/t/22_deflated_dir.t
@@ -5,7 +5,8 @@ use warnings;
 
 use Archive::Zip qw( :ERROR_CODES );
 use File::Spec;
-use t::common;
+use lib 't';
+use common;
 
 use Test::More tests => 4;
 

--- a/t/24_unicode_win32.t
+++ b/t/24_unicode_win32.t
@@ -15,7 +15,8 @@ use File::Temp;
 use File::Path;
 use File::Spec;
 
-use t::common;
+use lib 't';
+use common;
 
 #Initialy written for MSWin32 only, but I found a bug in memberNames() so
 # other systems should be tested too.


### PR DESCRIPTION
. may no longer be available by default in @INC - see https://rt.perl.org/Ticket/Display.html?id=127810