### PR TITLE
untaint_pat should be untaint_pattern

### DIFF
--- a/lib/Archive/Zip/Archive.pm
+++ b/lib/Archive/Zip/Archive.pm
@@ -778,7 +778,7 @@ sub addTree {
         $root = Win32::GetANSIPathName($root);
     }
     # File::Find will not untaint unless you explicitly pass the flag and regex pattern.
-    File::Find::find({ wanted => $wanted, untaint => 1, untaint_pat => $UNTAINT }, $root);
+    File::Find::find({ wanted => $wanted, untaint => 1, untaint_pattern => $UNTAINT }, $root);
 
     my $rootZipName = _asZipDirName($root, 1);    # with trailing slash
     my $pattern = $rootZipName eq './' ? '^' : "^\Q$rootZipName\E";


### PR DESCRIPTION
Paul Howarth Identified that I was using the variable name and not the key, apologies!
