### PR TITLE
Remove use lib from script/crc32

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for Perl extension Archive-Zip
 
+    - Do not load modules from unsafe directories
+
 1.64 Wed 12 Sep 2018
     - Fix for year 2030
 

--- a/script/crc32
+++ b/script/crc32
@@ -4,7 +4,6 @@
 
 use 5.006;
 use strict;
-use lib qw( blib/lib lib );
 use Archive::Zip;
 use FileHandle;
 

--- a/t/02_main.t
+++ b/t/02_main.t
@@ -16,7 +16,8 @@ use File::Spec;
 
 use Test::More tests => 141;
 
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 #####################################################################

--- a/t/03_ex.t
+++ b/t/03_ex.t
@@ -11,7 +11,8 @@ use File::Spec;
 use IO::File;
 
 use Test::More tests => 17;
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 sub runPerlCommand {

--- a/t/04_readmember.t
+++ b/t/04_readmember.t
@@ -10,7 +10,8 @@ use Archive::Zip qw( :ERROR_CODES :CONSTANTS );
 use Archive::Zip::MemberRead;
 
 use Test::More tests => 10;
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 use constant FILENAME => File::Spec->catfile(TESTDIR, 'member_read.zip');

--- a/t/05_tree.t
+++ b/t/05_tree.t
@@ -13,7 +13,8 @@ use FileHandle;
 use File::Spec;
 
 use Test::More tests => 6;
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 use constant FILENAME => File::Spec->catfile(TESTDIR, 'testing.txt');

--- a/t/06_update.t
+++ b/t/06_update.t
@@ -14,7 +14,8 @@ use File::Find ();
 use Archive::Zip qw( :ERROR_CODES :CONSTANTS );
 
 use Test::More tests => 12;
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 my ($testFileVolume, $testFileDirs, $testFileName) = File::Spec->splitpath($0);

--- a/t/07_filenames_of_0.t
+++ b/t/07_filenames_of_0.t
@@ -18,7 +18,8 @@ use Archive::Zip;
 use File::Path;
 use File::Spec;
 
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 mkpath([File::Spec->catdir(TESTDIR, 'folder')]);

--- a/t/08_readmember_record_sep.t
+++ b/t/08_readmember_record_sep.t
@@ -17,7 +17,8 @@ BEGIN {
 	plan(tests => 13);
 	$nl = $^O eq 'MSWin32' ? "\r\n" : "\n";
 }
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 # normalize newlines for the platform we are running on

--- a/t/10_chmod.t
+++ b/t/10_chmod.t
@@ -11,7 +11,8 @@ use File::Spec;
 use File::Path;
 use Archive::Zip;
 
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 sub get_perm {

--- a/t/14_leading_separator.t
+++ b/t/14_leading_separator.t
@@ -20,7 +20,8 @@ use Archive::Zip;
 use Cwd        ();
 use File::Spec ();
 
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 my $file_relative_path = File::Spec->catfile(TESTDIR, 'file.txt');

--- a/t/17_101092.t
+++ b/t/17_101092.t
@@ -8,7 +8,8 @@ BEGIN {
 }
 
 use Test::More tests => 2;
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 # RT #101092: Creation of non-standard streamed zip file

--- a/t/18_bug_92205.t
+++ b/t/18_bug_92205.t
@@ -8,7 +8,8 @@ BEGIN {
 }
 
 use Test::More tests => 32;
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 use Archive::Zip qw( :CONSTANTS );
 

--- a/t/19_bug_101240.t
+++ b/t/19_bug_101240.t
@@ -12,7 +12,8 @@ use File::Spec;
 use File::Path;
 use Archive::Zip qw(:CONSTANTS);
 
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 #101240: Possible issue with zero length files on Win32 when UNICODE is enabled

--- a/t/20_bug_github11.t
+++ b/t/20_bug_github11.t
@@ -9,7 +9,8 @@ use warnings;
 use Archive::Zip qw( :ERROR_CODES );
 use File::Spec;
 use File::Path;
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 use Test::More tests => 2;

--- a/t/21_zip64.t
+++ b/t/21_zip64.t
@@ -7,7 +7,8 @@ use warnings;
 
 use Archive::Zip qw( :ERROR_CODES );
 use File::Spec;
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 use Test::More tests => 1;

--- a/t/22_deflated_dir.t
+++ b/t/22_deflated_dir.t
@@ -5,7 +5,8 @@ use warnings;
 
 use Archive::Zip qw( :ERROR_CODES );
 use File::Spec;
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 use Test::More tests => 4;

--- a/t/24_unicode_win32.t
+++ b/t/24_unicode_win32.t
@@ -15,7 +15,8 @@ use File::Temp;
 use File::Path;
 use File::Spec;
 
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 #Initialy written for MSWin32 only, but I found a bug in memberNames() so

--- a/t/25_traversal.t
+++ b/t/25_traversal.t
@@ -4,7 +4,8 @@ use warnings;
 use Archive::Zip qw( :ERROR_CODES );
 use File::Spec;
 use File::Path;
-use lib 't';
+use FindBin;
+use lib $FindBin::Bin;
 use common;
 
 use Test::More tests => 41;


### PR DESCRIPTION
    That script is going to be install and
    should use default @INC values from Perl
    to load the modules.

    When run from this repo manually, it's recommended
    to use -Ilib.