### PR TITLE
Accept filenames that are stringifying objects

### DIFF
--- a/lib/Archive/Zip.pm
+++ b/lib/Archive/Zip.pm
@@ -10,6 +10,7 @@ use Compress::Raw::Zlib ();
 use File::Spec          ();
 use File::Temp          ();
 use FileHandle          ();
+use overload            ();
 
 use vars qw( $VERSION @ISA );
 
@@ -443,7 +444,7 @@ sub _newFileHandle {
     my $status = 1;
     my $handle;
 
-    if (ref($fd)) {
+    if (ref($fd) && !overload::OverloadedStringify($fd)) {
         if (_ISA($fd, 'IO::Scalar') or _ISA($fd, 'IO::String')) {
             $handle = $fd;
         } elsif (_ISA($fd, 'IO::Handle') or ref($fd) eq 'GLOB') {

--- a/t/26_filename_object.t
+++ b/t/26_filename_object.t
@@ -1,0 +1,31 @@
+#!/usr/bin/perl
+
+# Test that Archive::Zip works when supplied a filename that is an object which
+# stringifies (such as from Path::Tiny or Path::Class).
+
+use strict;
+use feature qw<say>;
+
+BEGIN {
+    $|  = 1;
+    $^W = 1;
+}
+use Archive::Zip qw( :ERROR_CODES );
+use Test::More tests => 3;
+
+# A simple object which uses overloading to behave as a string:
+{
+  package FileObj;
+  use overload q[""] => sub { $_[0]{name} };
+  sub new { bless {name => $_[1]}, $_[0] }
+}
+
+my $zip = Archive::Zip->new();
+my $filename_string = 't/data/perl.zip';
+my $filename_obj = FileObj->new($filename_string);
+open my $filehandle, '<', $filename_string
+    or die "Opening $filename_string failed: $!";
+
+is($zip->read($filename_string), AZ_OK, 'Read from filename as string');
+is($zip->read($filename_obj   ), AZ_OK, 'Read from filename as object');
+is($zip->read($filehandle     ), AZ_OK, 'Read from filehandle'        );


### PR DESCRIPTION
Sometimes a filename may be an object which stringifies to its path. As
such, it should work as a string anywhere that strings are. Modules
implementing such objects include Path::Tiny and Path::Class; they enable
filenames to be derived from components, other filenames, and so on.

Unfortunately Archive::Zip was, when passed such a filename object to the
->read method, trying to treat the filename as a file-handle, and failing
with the surprising error message:

  Can't locate object method "opened" via package "Path::Tiny" at
  /whatever/Archive-Zip/lib/Archive/Zip/Archive.pm line 585.

The attached patch fixes this, and provides a test for the behaviour.

It isn't even documented that the ->read method can accept a file-handle.
(The ->readFromFileHandle method is provided for that.) However, since it
was working, the patch is careful to ensure that that still works, and
contains a test for it: only an object that stringifies is treated as a
filename; other objects continue to be treated as file-handles.