### PR TITLE
Test for presence of Test::MockModule 

### DIFF
--- a/t/23_closed_handle.t
+++ b/t/23_closed_handle.t
@@ -6,9 +6,16 @@ use strict;
 use warnings;
 
 use Archive::Zip;
-use Test::MockModule;
+use Test::More;
 
-use Test::More tests => 2;
+eval { require Test::MockModule } ;
+
+if ($@) {
+    plan skip_all => "Module Test::MockModule not available"
+}
+else {   
+    plan tests => 2
+}
 
 # array to store open filhandles
 my @opened_filehandles;


### PR DESCRIPTION
The Travis build was failing with Perl 5.14 in 23_closed_handle.t because Test::MockModule wasn't installed.

This fix just gets it to skip the test if Test::MockModule isn't present.

Travis now passing 100%.