### PR TITLE
NetBSD doesn't mind empty zips

### DIFF
--- a/t/02_main.t
+++ b/t/02_main.t
@@ -84,6 +84,9 @@ SKIP: {
     skip("freebsd's unzip doesn't care about empty zips", 1)
         if $^O eq 'freebsd';
 
+    skip("netbsd's unzip doesn't care about empty zips", 1)
+        if $^O eq 'netbsd' ;        
+
     ok($status != 0);
 }
 


### PR DESCRIPTION
All failures on cpantestes for NetBSD are tripping
on this test (at least)

#   Failed test at t/02_main.t line 87.

Example
http://cpantesters.org/cpan/report/fadf5f64-cbdc-11e9-99fe-b031dbec7dbf