### PR TITLE
Add diag for test failure

### DIFF
--- a/t/22_deflated_dir.t
+++ b/t/22_deflated_dir.t
@@ -22,5 +22,6 @@ my ($status, $zipout) = testZip();
 # STDERR->print("status= $status, out=$zipout\n");
 SKIP: {
     skip( "test zip doesn't work", 1 ) if $testZipDoesntWork;
-    is( $status, 0, "output zip isn't corrupted" );
+    is( $status, 0, "output zip isn't corrupted" )
+        or diag "status=$status, out='$zipout'\n";
 }


### PR DESCRIPTION
Solaris seems to fail on this test. Add diag to failing test to collect data.

Example is http://cpantesters.org/cpan/report/94241d4c-77c1-11e9-95f3-b40aefbac26c