### PR TITLE
rework "defined or" for older perls

### DIFF
--- a/lib/Archive/Zip/Member.pm
+++ b/lib/Archive/Zip/Member.pm
@@ -673,7 +673,7 @@ sub _extractZip64ExtraField
             @fields = (undef, 0xffffffff, 0xffffffff, 0xffffffff, 0xffff);
         }
         else {
-            @fields = map { $_ // 0 } @_;
+            @fields = map { defined $_ ? $_ : 0 } @_;
         }
 
         my @fieldIndexes  = (0);
@@ -807,7 +807,7 @@ sub _unixToDosTime {
 sub _writeLocalFileHeader {
     my $self    = shift;
     my $fh      = shift;
-    my $refresh = shift // 0;
+    my $refresh = @_ ? shift : 0;
 
     my $zip64 = $self->zip64();
     my $hasDataDescriptor = $self->hasDataDescriptor();

--- a/lib/Archive/Zip/ZipFileMember.pm
+++ b/lib/Archive/Zip/ZipFileMember.pm
@@ -22,8 +22,8 @@ sub _newFromZipFile {
     my $class              = shift;
     my $fh                 = shift;
     my $externalFileName   = shift;
-    my $archiveZip64       = shift // 0;
-    my $possibleEocdOffset = shift // 0;     # normally 0
+    my $archiveZip64       = @_ ? shift : 0;
+    my $possibleEocdOffset = @_ ? shift : 0;     # normally 0
 
     my $self = $class->new(
         'eocdCrc32'                 => 0,


### PR DESCRIPTION
This change address the use of the `//` operator in #45 

Travis test still failing in 5.8 with another `pack` issue (see [here).](https://travis-ci.org/pmqs/perl-Archive-Zip/jobs/586236714) This time it is the use of `<` in the pack format string. Another feature added in 5,10.

`Invalid type '<' in unpack at /home/travis/build/pmqs/perl-Archive-Zip/build_dir/lib/Archive/Zip/Archive.pm line 880.`