### PR TITLE
Substitution replaced with appropriate transliteration

### DIFF
--- a/lib/Archive/Zip.pm
+++ b/lib/Archive/Zip.pm
@@ -593,7 +593,7 @@ sub _asZipDirName {
     my ($volume, $directories, $file) =
       File::Spec->splitpath(File::Spec->canonpath($name), $forceDir);
     $$volReturn = $volume if (ref($volReturn));
-    my @dirs = map { $_ =~ s{/}{_}g; $_ } File::Spec->splitdir($directories);
+    my @dirs = map { $_ =~ y{/}{_}; $_ } File::Spec->splitdir($directories);
     if (@dirs > 0) { pop(@dirs) unless $dirs[-1] }    # remove empty component
     push(@dirs, defined($file) ? $file : '');
 

--- a/lib/Archive/Zip/Archive.pm
+++ b/lib/Archive/Zip/Archive.pm
@@ -35,7 +35,7 @@ sub new {
     # Info-Zip 3.0 (I guess) seems to use the following values
     # for the version fields in the zip64 EOCD record:
     #
-    #   version made by: 
+    #   version made by:
     #     30 (plus upper byte indicating host system)
     #
     #   version needed to extract:
@@ -269,7 +269,7 @@ sub addMember {
     my $self = shift;
     my $newMember = (ref($_[0]) eq 'HASH') ? shift->{member} : shift;
     push(@{$self->{'members'}}, $newMember) if $newMember;
-    if($newMember && ($newMember->{bitFlag} & 0x800) 
+    if($newMember && ($newMember->{bitFlag} & 0x800)
                   && !utf8::is_utf8($newMember->{fileName})){
         $newMember->{fileName} = Encode::decode_utf8($newMember->{fileName});
     }
@@ -304,7 +304,7 @@ sub addFile {
     } else {
         $self->addMember($newMember);
     }
-    
+
     return $newMember;
 }
 
@@ -353,7 +353,7 @@ sub addDirectory {
     } else {
         $self->addMember($newMember);
     }
-    
+
     return $newMember;
 }
 
@@ -491,7 +491,7 @@ sub writeToFileHandle {
         #
         #   $member->_writeToFileHandle
         #       Determines a local flag value depending on
-        #       necessity and user desire and ors it to 
+        #       necessity and user desire and ors it to
         #       the object member
         #     $member->_writeLocalFileHeader
         #         Queries the object member to write appropriate

--- a/lib/Archive/Zip/FAQ.pod
+++ b/lib/Archive/Zip/FAQ.pod
@@ -139,14 +139,14 @@ B<Q:> Can I use Archive::Zip to extract Unix gzip files?
 
 B<A:> No.
 
-There is a distinction between Unix gzip files, and Zip archives that 
+There is a distinction between Unix gzip files, and Zip archives that
 also can use the gzip compression.
 
 Depending on the format of the gzip file, you can use L<Compress::Raw::Zlib>, or
 L<Archive::Tar> to decompress it (and de-archive it in the case of Tar files).
 
-You can unzip PKZIP/WinZip/etc/ archives using Archive::Zip (that's what 
-it's for) as long as any compressed members are compressed using 
+You can unzip PKZIP/WinZip/etc/ archives using Archive::Zip (that's what
+it's for) as long as any compressed members are compressed using
 Deflate compression.
 
 =head1 Add a directory/tree to a Zip
@@ -158,9 +158,9 @@ B<A:> You can use the Archive::Zip::addTree*() methods:
    use Archive::Zip;
    my $zip = Archive::Zip->new();
    # add all readable files and directories below . as xyz/*
-   $zip->addTree( '.', 'xyz' );	
+   $zip->addTree( '.', 'xyz' );
    # add all readable plain files below /abc as def/*
-   $zip->addTree( '/abc', 'def', sub { -f && -r } );	
+   $zip->addTree( '/abc', 'def', sub { -f && -r } );
    # add all .c files below /tmp as stuff/*
    $zip->addTreeMatching( '/tmp', 'stuff', '\.c$' );
    # add all .o files below /tmp as stuff/* if they aren't writable
@@ -257,18 +257,18 @@ and probably never will (unless I<you> write it).
 
 B<Q:> How can Archive::Zip can test the validity of a Zip file?
 
-B<A:> If you try to decompress the file, the gzip streams will report errors 
+B<A:> If you try to decompress the file, the gzip streams will report errors
 if you have garbage. Most of the time.
 
-If you try to open the file and a central directory structure can't be 
+If you try to open the file and a central directory structure can't be
 found, an error will be reported.
 
-When a file is being read, if we can't find a proper PK.. signature in 
+When a file is being read, if we can't find a proper PK.. signature in
 the right places we report a format error.
 
-If there is added garbage at the beginning of a Zip file (as inserted 
-by some viruses), you can find out about it, but Archive::Zip will ignore it, 
-and you can still use the archive. When it gets written back out the 
+If there is added garbage at the beginning of a Zip file (as inserted
+by some viruses), you can find out about it, but Archive::Zip will ignore it,
+and you can still use the archive. When it gets written back out the
 added stuff will be gone.
 
 There are two ready-to-use utilities in the examples directory that can

--- a/lib/Archive/Zip/Member.pm
+++ b/lib/Archive/Zip/Member.pm
@@ -103,7 +103,7 @@ sub new {
     # headers, regardless of whether the member has an zip64
     # extended information extra field or not:
     #
-    #   version made by: 
+    #   version made by:
     #     30
     #
     #   version needed to extract:
@@ -248,7 +248,7 @@ sub fileName {
     my $self    = shift;
     my $newName = shift;
     if (defined $newName) {
-        $newName =~ s{[\\/]+}{/}g;    # deal with dos/windoze problems
+        $newName =~ y{\\/}{/}s;    # deal with dos/windoze problems
         $self->{'fileName'} = $newName;
     }
     return $self->{'fileName'};
@@ -876,7 +876,7 @@ sub _writeLocalFileHeader {
 
         $localExtraField .= pack('S< S< Q< Q<',
                                  0x0001, 16,
-                                 $zip64UncompressedSize, 
+                                 $zip64UncompressedSize,
                                  $zip64CompressedSize);
     }
 
@@ -892,7 +892,7 @@ sub _writeLocalFileHeader {
            $versionNeededToExtract,
            $self->{'bitFlag'},
            $self->desiredCompressionMethod(),
-           $self->lastModFileDateTime(), 
+           $self->lastModFileDateTime(),
            $crc32,
            $compressedSize,
            $uncompressedSize,
@@ -1057,7 +1057,7 @@ sub _writeCentralDirectoryFileHeader {
     return
       (AZ_OK,
        CENTRAL_DIRECTORY_FILE_HEADER_LENGTH +
-       SIGNATURE_LENGTH + 
+       SIGNATURE_LENGTH +
        $fileNameLength +
        $extraFieldLength +
        $fileCommentLength)
@@ -1280,7 +1280,7 @@ sub contents {
             : undef;
 
         # Now call the subclass contents method
-        my $retval = 
+        my $retval =
           $self->contents(pack('C0a*', $newContents)); # in case of Unicode
 
         return wantarray ? ($retval, AZ_OK) : $retval;

--- a/lib/Archive/Zip/MemberRead.pm
+++ b/lib/Archive/Zip/MemberRead.pm
@@ -334,7 +334,7 @@ sub read {
 Sreeji K. Das E<lt>sreeji_k@yahoo.comE<gt>
 
 See L<Archive::Zip> by Ned Konz without which this module does not make
-any sense! 
+any sense!
 
 Minor mods by Ned Konz.
 

--- a/lib/Archive/Zip/Tree.pm
+++ b/lib/Archive/Zip/Tree.pm
@@ -4,7 +4,7 @@ use strict;
 use vars qw{$VERSION};
 
 BEGIN {
-	$VERSION = '1.67';
+    $VERSION = '1.67';
 }
 
 use Archive::Zip;

--- a/lib/Archive/Zip/ZipFileMember.pm
+++ b/lib/Archive/Zip/ZipFileMember.pm
@@ -206,8 +206,8 @@ sub _skipLocalFileHeader {
           if ( $oldCrc32 != $self->{'crc32'}
             || $oldUncompressedSize != $self->{'uncompressedSize'});
 
-        $self->{'crc32'} = 0 
-            if $self->compressionMethod() == COMPRESSION_STORED ; 
+        $self->{'crc32'} = 0
+            if $self->compressionMethod() == COMPRESSION_STORED ;
     }
 
     return AZ_OK;


### PR DESCRIPTION
Another attempt for this [PR](https://github.com/redhotpenguin/perl-Archive-Zip/pull/61) :)

> Hello!
> The reason is: transliteration can be 100x faster and more expressive than substitution for such situations