### PR TITLE
Don't fail t/26_bzip2.t if unzip built without bzip2 support

### DIFF
--- a/t/26_bzip2.t
+++ b/t/26_bzip2.t
@@ -30,6 +30,14 @@ $zip->read($infile);
 $zip->writeToFileNamed($outfile);
 
 my ($status, $reason) = testZip($outfile);
+
+# If unzip cannot handle bzip2 compression, it will return exit status 81
+# Treat this the same as success
+if ($status == 81 * 256) {
+    warn("ziptest said: $reason\n");
+    $status = 0;
+}
+
 is $status, 0, "testZip ok after $infile to $outfile"
     or warn("ziptest said: $reason\n");
 


### PR DESCRIPTION
Without this (or similar) fix:
```
$ make test
PERL_DL_NONLAZY=1 /usr/bin/perl "-MExtUtils::Command::MM" "-e" "test_harness(0, 'blib/lib', 'blib/arch')" t/*.t
t/01_compile.t ................ ok
t/02_main.t ................... ok
t/03_ex.t ..................... ok
t/04_readmember.t ............. ok
t/05_tree.t ................... ok
t/06_update.t ................. ok
t/07_filenames_of_0.t ......... ok
t/08_readmember_record_sep.t .. ok
t/09_output_record_sep.t ...... ok
t/10_chmod.t .................. ok
t/11_explorer.t ............... ok
t/12_bug_47223.t .............. skipped: Only required on Win32.
t/13_bug_46303.t .............. ok
t/14_leading_separator.t ...... ok
t/15_decrypt.t ................ ok
t/16_decrypt.t ................ ok
t/17_101092.t ................. ok
t/18_bug_92205.t .............. ok
t/19_bug_101240.t ............. ok
t/20_bug_github11.t ........... ok
t/21_zip64.t .................. ok
t/22_deflated_dir.t ........... ok
t/23_closed_handle.t .......... ok
t/24_unicode_win32.t .......... ok
t/25_traversal.t .............. ok

ziptest said: Archive:  /tmp/testout-QP8dh.zip
   skipping: README                  need PK compat. v4.6 (can do v4.5)
Caution:  zero files tested in /tmp/testout-QP8dh.zip.
1 file skipped because of unsupported compression or encoding.

t/26_bzip2.t ..................
Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/1 subtests
t/27_symlinks.t ............... ok
t/28_zip64_unsupported.t ...... skipped: Zip64 format is supported.

Test Summary Report
-------------------
t/26_bzip2.t                (Wstat: 256 Tests: 1 Failed: 1)
  Failed test:  1
  Non-zero exit status: 1
Files=28, Tests=729,  4 wallclock secs ( 0.11 usr  0.02 sys +  2.91 cusr  0.51 csys =  3.55 CPU)
Result: FAIL
Failed 1/28 test programs. 1/729 subtests failed.
```
The unzip program returns an exit code of 81 in the event of it encountering
a file with an unsupported compression scheme. Treat this as OK so that the
test will still pass.