### PR TITLE
`expandTree`: allow traversals (symlinks, `..` path elements) in destination directories

### DIFF
--- a/t/25_traversal.t
+++ b/t/25_traversal.t
@@ -34,7 +34,7 @@ ok(chdir testPath(), "Working directory changed");
 # Symlink tests make sense only if a file system supports them.
 my $symlinks_not_supported;
 {
-    my $link = testPath('trylink');
+    my $link = testPathInit('trylink') or BAIL_OUT("Failed to create parent directory of `trylink`: $!");
     $symlinks_not_supported = !eval { symlink('.', $link) };
     unlink($link);
 }

--- a/t/common.pm
+++ b/t/common.pm
@@ -8,6 +8,8 @@ use warnings;
 
 use Carp qw(croak longmess);
 use Config;
+use File::Basename qw(fileparse);
+use File::Path qw(make_path);
 use File::Spec;
 use File::Spec::Unix;
 use File::Temp qw(tempfile tempdir);
@@ -20,7 +22,8 @@ use Exporter qw(import);
 @common::EXPORT = qw(TESTDIR INPUTZIP OUTPUTZIP
                      TESTSTRING TESTSTRINGLENGTH TESTSTRINGCRC
                      PATH_REL PATH_ABS PATH_ZIPFILE PATH_ZIPDIR PATH_ZIPABS
-                     passThrough readFile execProc execPerl dataPath testPath
+                     passThrough readFile execProc execPerl dataPath
+                     testPath testDirInit testPathInit
                      azbinis azok azis
                      azopen azuztok azwok);
 
@@ -170,6 +173,21 @@ sub testPath
     else {
         return File::Spec::Unix->catfile(@cwdDirs, @testDirs, @pathItems);
     }
+}
+
+sub testDirInit {
+    my $path = &testPath;
+    note("Creating test directory $path");
+    make_path($path) or return;
+    return $path;
+}
+
+sub testPathInit {
+    my $path = &testPath;
+    my $dirs = (fileparse($path))[1];
+    note("Creating parent directory $dirs of test path $path");
+    make_path($dirs) or return;
+    return $path;
 }
 
 ### Initialization


### PR DESCRIPTION
This PR updates `Archive::Zip::Archive->extractTree` so that symlinks and `..` elements are permitted **in the destination directory**, while continuing to forbid them in the components of archive extraction paths that are under or relative to the destination directory.

That is, this PR makes it okay to do this:

```perl
$zip->extractTree({ zipPath => '/foo/bar/../baz/quux/..' });
```

And this, given that one or more of `/foo`, `/foo/bar`, `/foo/bar/baz`, and `/foo/bar/baz/quux` are symlinks to directories:

```perl
$zip->extractTree({ zipPath => '/foo/bar/baz/quux' });
```

As I understand it, the purpose of `Archive::Zip::Archive::_extractionNameIsSafe` is to reduce (possibly eliminate) the risk of writes to arbitrary filesystem locations.  As currently implemented, however, it forbids writes to **any** path that contains a symlink or `..` element -- but the destination directory isn't an arbitrary location, it's where the user wants to extract the archive's contents.

My use case is the following: I'm running a service under systemd; under the hood, this service uses `Archive::Zip` for zip file extraction.  The service also uses systemd's `DynamicUser` and `CacheDirectory` options.  With these options in effect, the extraction directory is `/var/cache/myservice`, and `/var/cache/myservice` is a symlink to `/var/cache/private/myservice`.  Because `/var/cache/myservice` is a symlink, `Archive::Zip` refuses to extract archives to `/var/cache/myservice`.  Take the extraction path `/var/cache/myservice/foo/bar/baz`: even if none of `/var/cache/myservice/foo`, `/var/cache/myservice/foo/bar`, or `/var/cache/myservice/foo/bar/baz` are symlinks, `Archive::Zip` bails out.  This seems wrong to me: there is no traversal here, except possibly the traversal that I myself have told `Archive::Zip` to perform.

Thanks in advance for your consideration!