### PR TITLE
Bad zip files with missing uncompressed size

### DIFF
--- a/lib/Archive/Zip/ZipFileMember.pm
+++ b/lib/Archive/Zip/ZipFileMember.pm
@@ -356,7 +356,7 @@ sub _readDataDescriptor {
       unless defined($self->{'eocdCrc32'});
     $self->{'crc32'}            = $crc32;
     $self->{'compressedSize'}   = $compressedSize;
-    $self->{'uncompressedSize'} = $uncompressedSize;
+    $self->{'uncompressedSize'} = $uncompressedSize if $uncompressedSize;
 
     return AZ_OK;
 }


### PR DESCRIPTION
There are buggy libraries out there creating zip files with general purpose bit flag set but not populating the data descriptor

This has caused completely valid computed uncompressed size to be wiped out and breaks processing of files